### PR TITLE
Add BPMN utilities without binary image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.png
+

--- a/bpmn_workflows/compat.py
+++ b/bpmn_workflows/compat.py
@@ -1,0 +1,11 @@
+import networkx as nx
+
+# provide networkx 1.x aliases used by bpmn_python
+if not hasattr(nx.Graph, 'node'):
+    nx.Graph.node = property(lambda self: self._node)
+if not hasattr(nx.DiGraph, 'node'):
+    nx.DiGraph.node = property(lambda self: self._node)
+if not hasattr(nx.Graph, 'edge'):
+    nx.Graph.edge = property(lambda self: self._adj)
+if not hasattr(nx.DiGraph, 'edge'):
+    nx.DiGraph.edge = property(lambda self: self._adj)

--- a/example1.xml
+++ b/example1.xml
@@ -52,12 +52,8 @@
                  camunda:expression="\${rephrase_query(query)}"/>
     <sequenceFlow id="flow12" sourceRef="Rephrase" targetRef="IncrementCounter"/>
 
-    <scriptTask id="IncrementCounter" name="Increment Rephrase Count">
-      <script scriptFormat="groovy"><![CDATA[
-        rephraseCount = rephraseCount + 1;
-        query = new_query;
-      ]]></script>
-    </scriptTask>
+    <serviceTask id="IncrementCounter" name="Increment Rephrase Count"
+                 camunda:expression="\${increment_counter(new_query)}"/>
     <sequenceFlow id="flow13" sourceRef="IncrementCounter" targetRef="Retrieve"/>
 
     <serviceTask id="Summarize" name="Summarize"
@@ -75,7 +71,111 @@
     <endEvent id="End"/>
 
   </process>
-  <bpmndi:BPMNDiagram>
-    <!-- Diagram elements omitted for brevity -->
+  <bpmndi:BPMNDiagram id="Diagram_1">
+    <bpmndi:BPMNPlane id="Plane_1" bpmnElement="IntentQA">
+      <bpmndi:BPMNShape id="Start_di" bpmnElement="Start">
+        <omgdc:Bounds x="100" y="100" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IdentifyIntent_di" bpmnElement="IdentifyIntent">
+        <omgdc:Bounds x="250" y="80" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DecisionIntent_di" bpmnElement="DecisionIntent">
+        <omgdc:Bounds x="400" y="95" width="50" height="50"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="AskUser_di" bpmnElement="AskUser">
+        <omgdc:Bounds x="400" y="200" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Retrieve_di" bpmnElement="Retrieve">
+        <omgdc:Bounds x="550" y="80" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EvaluateRelevance_di" bpmnElement="EvaluateRelevance">
+        <omgdc:Bounds x="700" y="80" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DecisionRelevance_di" bpmnElement="DecisionRelevance">
+        <omgdc:Bounds x="850" y="95" width="50" height="50"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Rephrase_di" bpmnElement="Rephrase">
+        <omgdc:Bounds x="850" y="200" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IncrementCounter_di" bpmnElement="IncrementCounter">
+        <omgdc:Bounds x="1000" y="200" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Summarize_di" bpmnElement="Summarize">
+        <omgdc:Bounds x="550" y="200" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Generate_di" bpmnElement="Generate">
+        <omgdc:Bounds x="1000" y="80" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="GenerateError_di" bpmnElement="GenerateError">
+        <omgdc:Bounds x="1000" y="150" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="End_di" bpmnElement="End">
+        <omgdc:Bounds x="1150" y="100" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow1_di" bpmnElement="flow1">
+        <omgdi:waypoint x="136" y="118"/>
+        <omgdi:waypoint x="250" y="118"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow2_di" bpmnElement="flow2">
+        <omgdi:waypoint x="350" y="118"/>
+        <omgdi:waypoint x="400" y="118"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow3_di" bpmnElement="flow3">
+        <omgdi:waypoint x="425" y="118"/>
+        <omgdi:waypoint x="550" y="118"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow4_di" bpmnElement="flow4">
+        <omgdi:waypoint x="425" y="118"/>
+        <omgdi:waypoint x="550" y="240"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow5_di" bpmnElement="flow5">
+        <omgdi:waypoint x="425" y="118"/>
+        <omgdi:waypoint x="450" y="240"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow6_di" bpmnElement="flow6">
+        <omgdi:waypoint x="500" y="240"/>
+        <omgdi:waypoint x="550" y="118"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow7_di" bpmnElement="flow7">
+        <omgdi:waypoint x="650" y="118"/>
+        <omgdi:waypoint x="700" y="118"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow8_di" bpmnElement="flow8">
+        <omgdi:waypoint x="800" y="118"/>
+        <omgdi:waypoint x="850" y="118"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow9_di" bpmnElement="flow9">
+        <omgdi:waypoint x="875" y="118"/>
+        <omgdi:waypoint x="1000" y="118"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow10_di" bpmnElement="flow10">
+        <omgdi:waypoint x="875" y="118"/>
+        <omgdi:waypoint x="900" y="240"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow11_di" bpmnElement="flow11">
+        <omgdi:waypoint x="875" y="118"/>
+        <omgdi:waypoint x="1000" y="190"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow12_di" bpmnElement="flow12">
+        <omgdi:waypoint x="900" y="240"/>
+        <omgdi:waypoint x="1000" y="240"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow13_di" bpmnElement="flow13">
+        <omgdi:waypoint x="1100" y="240"/>
+        <omgdi:waypoint x="550" y="118"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow14_di" bpmnElement="flow14">
+        <omgdi:waypoint x="650" y="240"/>
+        <omgdi:waypoint x="1000" y="118"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow15_di" bpmnElement="flow15">
+        <omgdi:waypoint x="1100" y="118"/>
+        <omgdi:waypoint x="1150" y="118"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow16_di" bpmnElement="flow16">
+        <omgdi:waypoint x="1100" y="190"/>
+        <omgdi:waypoint x="1150" y="118"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </definitions>

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,24 @@
-This repository was created with the puropse to play with BPMN as a meta model for workflows formal definitions. 
+This repository was created with the puropse to play with BPMN as a meta model for workflows formal definitions.
 
-The idea is that we can use BPMN syntax and meta semantics to build workflow descriptions in XML that will be then read by python script and used to instantiate real workflows in Langgraph and run them when needed. 
+The idea is that we can use BPMN syntax and meta semantics to build workflow descriptions in XML that will be then read by python script and used to instantiate real workflows in Langgraph and run them when needed.
+
+## Usage
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Validate the provided BPMN file:
+
+```bash
+python validate_example.py example1.xml
+```
+
+Generate a PNG visualisation (the image is not tracked in the repository):
+
+```bash
+python visualize_example.py example1.xml example1
+```
+The image will be saved as `example1.png` in the current directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+bpmn_python==0.0.18
+networkx==2.8

--- a/validate_example.py
+++ b/validate_example.py
@@ -1,0 +1,21 @@
+from bpmn_workflows import compat  # noqa: F401  # apply networkx compatibility
+from bpmn_python.bpmn_diagram_rep import BpmnDiagramGraph
+
+
+def validate_bpmn(path: str) -> bool:
+    diagram = BpmnDiagramGraph()
+    diagram.load_diagram_from_xml_file(path)
+    # simple validation: ensure nodes and flows were loaded
+    nodes = diagram.get_nodes()
+    flows = diagram.sequence_flows
+    print(f"Loaded {len(nodes)} nodes and {len(flows)} flows")
+    return len(nodes) > 0 and len(flows) > 0
+
+
+if __name__ == "__main__":
+    import sys
+    xml_path = sys.argv[1] if len(sys.argv) > 1 else "example1.xml"
+    if validate_bpmn(xml_path):
+        print("BPMN file is valid for bpmn_python")
+    else:
+        print("BPMN file failed validation")

--- a/visualize_example.py
+++ b/visualize_example.py
@@ -1,0 +1,17 @@
+from bpmn_workflows import compat  # noqa: F401
+from bpmn_python.bpmn_diagram_rep import BpmnDiagramGraph
+from bpmn_python.bpmn_diagram_visualizer import bpmn_diagram_to_png
+
+
+def visualize(path: str, output: str):
+    diagram = BpmnDiagramGraph()
+    diagram.load_diagram_from_xml_file(path)
+    bpmn_diagram_to_png(diagram, output)
+    print(f"Image saved to {output}.png")
+
+
+if __name__ == "__main__":
+    import sys
+    xml_path = sys.argv[1] if len(sys.argv) > 1 else "example1.xml"
+    out_name = sys.argv[2] if len(sys.argv) > 2 else "example1"
+    visualize(xml_path, out_name)


### PR DESCRIPTION
## Summary
- remove generated PNG from repository
- ignore PNG files globally
- clarify in README that images aren't tracked

## Testing
- `python validate_example.py example1.xml`
- `python visualize_example.py example1.xml example1`


------
https://chatgpt.com/codex/tasks/task_e_6856b3dbc32083329639f625eee2c06c