### PR TITLE
Add branch tests and function mapping

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,0 +1,12 @@
+import run_bpmn_workflow as runner
+import workflow_functions as wf
+
+def run_workflow(xml_path: str, fn_overrides=None, params=None):
+    fn_map = {name: getattr(wf, name) for name in dir(wf) if not name.startswith("_")}
+    if fn_overrides:
+        fn_map.update(fn_overrides)
+    app = runner.build_graph(xml_path, functions=fn_map)
+    input_kwargs = {"input_text": "hello", "rephraseCount": 0}
+    if params:
+        input_kwargs.update(params)
+    return app.invoke(input_kwargs)

--- a/tests/test_branch_not_clear.py
+++ b/tests/test_branch_not_clear.py
@@ -1,0 +1,14 @@
+from .helper import run_workflow
+
+XML_PATH = "examples/example_1/example1.xml"
+
+
+def intent_other(state):
+    return {"intent": "not_clear"}
+
+
+def test_branch_not_clear():
+    result = run_workflow(XML_PATH, {"identify_user_intent": intent_other})
+    assert result["intent"] == "not_clear"
+    assert "query" in result
+    assert "answer" in result

--- a/tests/test_branch_qa_error.py
+++ b/tests/test_branch_qa_error.py
@@ -1,0 +1,12 @@
+from .helper import run_workflow
+
+XML_PATH = "examples/example_1/example1.xml"
+
+
+def eval_bad(state):
+    return {"relevance": "BAD"}
+
+def test_branch_qa_error():
+    result = run_workflow(XML_PATH, {"evaluate_relevance": eval_bad}, params={"rephraseCount": 3})
+    assert result.get("relevance") == "BAD"
+    assert "answer" in result

--- a/tests/test_branch_qa_ok.py
+++ b/tests/test_branch_qa_ok.py
@@ -1,0 +1,9 @@
+from .helper import run_workflow
+
+XML_PATH = "examples/example_1/example1.xml"
+
+def test_branch_qa_ok():
+    result = run_workflow(XML_PATH)
+    assert result["intent"] == "qa"
+    assert result["relevance"] == "OK"
+    assert "answer" in result

--- a/tests/test_branch_qa_rephrase.py
+++ b/tests/test_branch_qa_rephrase.py
@@ -1,0 +1,15 @@
+from .helper import run_workflow
+
+XML_PATH = "examples/example_1/example1.xml"
+
+
+def eval_relevance(state):
+    if state.get("rephraseCount", 0) == 0:
+        return {"relevance": "BAD"}
+    return {"relevance": "OK"}
+
+def test_branch_qa_rephrase():
+    result = run_workflow(XML_PATH, {"evaluate_relevance": eval_relevance})
+    assert result["rephraseCount"] == 1
+    assert result["relevance"] == "OK"
+    assert "answer" in result

--- a/tests/test_branch_summarize.py
+++ b/tests/test_branch_summarize.py
@@ -1,0 +1,14 @@
+from .helper import run_workflow
+
+XML_PATH = "examples/example_1/example1.xml"
+
+
+def intent_summarize(state):
+    return {"intent": "summarization"}
+
+
+def test_branch_summarize():
+    result = run_workflow(XML_PATH, {"identify_user_intent": intent_summarize})
+    assert result["intent"] == "summarization"
+    assert "summary" in result
+    assert "answer" in result


### PR DESCRIPTION
## Summary
- make workflow runner allow passing function registry
- fix parsing of conditional expressions
- add helper for running workflows in tests
- create tests covering five branches of the sample workflow
- require explicit mapping of real functions and workflow path

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f7c145508332a0cfbfd1cba0279f