### PR TITLE
Add Postgres checkpoint support with resume tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,6 @@ bpmn_python==0.0.18
 networkx==2.8
 
 langgraph>=0.4
+langgraph-checkpoint-postgres
+psycopg[binary]
 xmlschema

--- a/run_bpmn_workflow.py
+++ b/run_bpmn_workflow.py
@@ -90,7 +90,11 @@ def make_router(flows):
     return router
 
 
-def build_graph(xml_path: str, functions: Dict[str, Any]):
+def build_graph(
+    xml_path: str,
+    functions: Dict[str, Any],
+    checkpointer: Any | None = None,
+):
     nodes, flows = parse_bpmn(xml_path)
     outgoing: Dict[str, list] = {}
     for fl in flows:
@@ -124,7 +128,7 @@ def build_graph(xml_path: str, functions: Dict[str, Any]):
         raise ValueError("Workflow must have start and end events")
     graph.set_entry_point(starts[0])
     graph.set_finish_point(ends[0])
-    return graph.compile()
+    return graph.compile(checkpointer=checkpointer)
 
 
 if __name__ == "__main__":

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,12 +1,29 @@
 import run_bpmn_workflow as runner
 import workflow_functions as wf
 
-def run_workflow(xml_path: str, fn_overrides=None, params=None):
-    fn_map = {name: getattr(wf, name) for name in dir(wf) if not name.startswith("_")}
+def run_workflow(
+    xml_path: str,
+    fn_overrides=None,
+    params=None,
+    *,
+    checkpointer=None,
+    thread_id="test",
+    interrupt_after=None,
+):
+    fn_map = {
+        name: getattr(wf, name)
+        for name in dir(wf)
+        if not name.startswith("_")
+    }
     if fn_overrides:
         fn_map.update(fn_overrides)
-    app = runner.build_graph(xml_path, functions=fn_map)
+    app = runner.build_graph(xml_path, functions=fn_map, checkpointer=checkpointer)
     input_kwargs = {"input_text": "hello", "rephraseCount": 0}
     if params:
         input_kwargs.update(params)
-    return app.invoke(input_kwargs)
+    config = {"configurable": {"thread_id": thread_id}}
+    return app.invoke(
+        input_kwargs,
+        config,
+        interrupt_after=interrupt_after,
+    )

--- a/tests/test_postgres_resume.py
+++ b/tests/test_postgres_resume.py
@@ -1,0 +1,75 @@
+import uuid
+import psycopg
+from langgraph.checkpoint.postgres import PostgresSaver
+from .helper import run_workflow
+
+XML_PATH = "examples/example_1/example1.xml"
+DB_ROOT_URI = "postgresql://postgres:postgres@localhost/postgres"
+
+def create_saver():
+    dbname = "test_" + uuid.uuid4().hex[:8]
+    with psycopg.connect(DB_ROOT_URI, autocommit=True) as conn:
+        conn.execute(f"CREATE DATABASE {dbname}")
+    uri = f"postgresql://postgres:postgres@localhost/{dbname}"
+    saver_cm = PostgresSaver.from_conn_string(uri)
+    saver = saver_cm.__enter__()
+    saver.setup()
+    return saver, dbname, saver_cm
+
+def drop_saver(saver, dbname, saver_cm):
+    saver_cm.__exit__(None, None, None)
+    with psycopg.connect(DB_ROOT_URI, autocommit=True) as conn:
+        conn.execute(f"DROP DATABASE IF EXISTS {dbname}")
+
+def test_postgres_resume_success():
+    saver, dbname, cm = create_saver()
+    try:
+        # first run interrupted before any task executes
+        result = run_workflow(
+            XML_PATH,
+            checkpointer=saver,
+            thread_id="flow1",
+            interrupt_after="*",
+        )
+        assert result["input_text"] == "hello"
+        assert "answer" not in result
+
+        # second run continues from saved state
+        result2 = run_workflow(
+            XML_PATH,
+            checkpointer=saver,
+            thread_id="flow1",
+        )
+        assert result2["intent"] == "qa"
+        assert "answer" in result2
+    finally:
+        drop_saver(saver, dbname, cm)
+
+def test_postgres_resume_error():
+    saver, dbname, cm = create_saver()
+    try:
+        def always_bad(state):
+            return {"relevance": "BAD"}
+
+        result = run_workflow(
+            XML_PATH,
+            fn_overrides={"evaluate_relevance": always_bad},
+            params={"rephraseCount": 3},
+            checkpointer=saver,
+            thread_id="flow2",
+            interrupt_after="*",
+        )
+        assert result["input_text"] == "hello"
+        assert "answer" not in result
+
+        result2 = run_workflow(
+            XML_PATH,
+            fn_overrides={"evaluate_relevance": always_bad},
+            params={"rephraseCount": 3},
+            checkpointer=saver,
+            thread_id="flow2",
+        )
+        assert result2.get("relevance") == "BAD"
+        assert "answer" in result2
+    finally:
+        drop_saver(saver, dbname, cm)


### PR DESCRIPTION
## Summary
- add `langgraph-checkpoint-postgres` and `psycopg[binary]` dependencies
- allow specifying a checkpointer when building graphs
- extend helper to pass thread_id and interrupts
- add tests covering graph resume using a temporary Postgres database

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685718c061748332adc07cb038018590