### PR TITLE
Add deepresearch workflow and tests

### DIFF
--- a/steps/deepresearch_functions.py
+++ b/steps/deepresearch_functions.py
@@ -1,0 +1,68 @@
+from typing import Dict, Any, List
+from bpmn_ext.bpmn_ext import bpmn_op
+
+@bpmn_op(
+    name="analyse_user_query",
+    inputs={"query": str},
+    outputs={"extended_query": str, "questions": list},
+)
+def analyse_user_query(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Analyse the user query and decide if clarification is needed."""
+    return {
+        "extended_query": f"{state.get('query', '')} extended",
+        "questions": [],
+    }
+
+@bpmn_op(
+    name="ask_questions",
+    inputs={"questions": list},
+    outputs={"clarifications": str},
+)
+def ask_questions(state: Dict[str, Any]) -> Dict[str, Any]:
+    return {"clarifications": "clarified"}
+
+@bpmn_op(
+    name="query_extender",
+    inputs={"query": str, "clarifications": str, "next_query": str},
+    outputs={"extended_query": str},
+)
+def query_extender(state: Dict[str, Any]) -> Dict[str, Any]:
+    state["iteration"] = state.get("iteration", 0) + 1
+    return {"extended_query": state.get("next_query") or state.get("query", "")}
+
+@bpmn_op(
+    name="retrieve_from_web",
+    inputs={"extended_query": str},
+    outputs={"chunks": list},
+)
+def retrieve_from_web(state: Dict[str, Any]) -> Dict[str, Any]:
+    q = state.get("extended_query", "")
+    return {"chunks": [f"chunk for {q}"]}
+
+@bpmn_op(
+    name="process_info",
+    inputs={"query": str, "chunks": list, "answer_draft": str},
+    outputs={"answer_draft": str},
+)
+def process_info(state: Dict[str, Any]) -> Dict[str, Any]:
+    draft = state.get("answer_draft", "")
+    chunks = state.get("chunks", [])
+    return {"answer_draft": draft + f" info from {chunks}"}
+
+@bpmn_op(
+    name="answer_validate",
+    inputs={"answer_draft": str},
+    outputs={"is_enough": str, "next_query": str},
+)
+def answer_validate(state: Dict[str, Any]) -> Dict[str, Any]:
+    if state.get("iteration", 0) >= 1:
+        return {"is_enough": "GOOD", "next_query": ""}
+    return {"is_enough": "BAD", "next_query": "next"}
+
+@bpmn_op(
+    name="final_answer_generation",
+    inputs={"query": str, "answer_draft": str},
+    outputs={"final_answer": str},
+)
+def final_answer_generation(state: Dict[str, Any]) -> Dict[str, Any]:
+    return {"final_answer": state.get("answer_draft", "")}

--- a/tests/test_deepresearch.py
+++ b/tests/test_deepresearch.py
@@ -1,0 +1,24 @@
+from .helper import run_workflow
+import steps.deepresearch_functions as drf
+
+XML_PATH = "workflows/deepresearch/deepresearch.xml"
+
+FN_MAP = {name: getattr(drf, name) for name in dir(drf) if not name.startswith("_")}
+
+
+def test_deepresearch_ok():
+    result = run_workflow(XML_PATH, fn_overrides=FN_MAP, params={"query": "hello"})
+    assert result.get("final_answer")
+
+
+def test_deepresearch_loop():
+    def validate(state):
+        if state.get("iteration", 0) < 2:
+            return {"is_enough": "BAD", "next_query": "next"}
+        return {"is_enough": "GOOD", "next_query": ""}
+
+    overrides = dict(FN_MAP)
+    overrides["answer_validate"] = validate
+    result = run_workflow(XML_PATH, fn_overrides=overrides, params={"query": "hello"})
+    assert result.get("final_answer")
+    assert result.get("iteration", 0) == 2

--- a/workflows/deepresearch/bpmn_ext.xsd
+++ b/workflows/deepresearch/bpmn_ext.xsd
@@ -1,0 +1,55 @@
+<?xml version="1.0" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://your-company.com/bpmn-ext" targetNamespace="http://your-company.com/bpmn-ext" elementFormDefault="qualified">
+  <xs:element name="operation">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="in" minOccurs="0" maxOccurs="unbounded" type="inType"/>
+        <xs:element name="out" minOccurs="0" maxOccurs="unbounded" type="outType"/>
+      </xs:sequence>
+      <xs:attribute name="name" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="analyse_user_query"/>
+            <xs:enumeration value="answer_validate"/>
+            <xs:enumeration value="ask_questions"/>
+            <xs:enumeration value="final_answer_generation"/>
+            <xs:enumeration value="process_info"/>
+            <xs:enumeration value="query_extender"/>
+            <xs:enumeration value="retrieve_from_web"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="inType">
+    <xs:attribute name="name" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="answer_draft"/>
+          <xs:enumeration value="chunks"/>
+          <xs:enumeration value="clarifications"/>
+          <xs:enumeration value="extended_query"/>
+          <xs:enumeration value="next_query"/>
+          <xs:enumeration value="query"/>
+          <xs:enumeration value="questions"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="outType">
+    <xs:attribute name="name" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="answer_draft"/>
+          <xs:enumeration value="chunks"/>
+          <xs:enumeration value="clarifications"/>
+          <xs:enumeration value="extended_query"/>
+          <xs:enumeration value="final_answer"/>
+          <xs:enumeration value="is_enough"/>
+          <xs:enumeration value="next_query"/>
+          <xs:enumeration value="questions"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:complexType>
+</xs:schema>

--- a/workflows/deepresearch/deepresearch.xml
+++ b/workflows/deepresearch/deepresearch.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+             xmlns:ext="http://your-company.com/bpmn-ext"
+             xsi:schemaLocation="http://your-company.com/bpmn-ext bpmn_ext.xsd"
+             targetNamespace="http://example.com/deepresearch">
+  <process id="DeepResearch" isExecutable="true">
+    <startEvent id="Start"/>
+
+    <serviceTask id="AnalyseQuery" name="Analyse Query"
+                 camunda:expression="${analyse_user_query(query)}">
+      <extensionElements>
+        <ext:operation name="analyse_user_query">
+          <ext:in name="query"/>
+          <ext:out name="extended_query"/>
+          <ext:out name="questions"/>
+        </ext:operation>
+      </extensionElements>
+    </serviceTask>
+    <sequenceFlow id="flow1" sourceRef="Start" targetRef="AnalyseQuery"/>
+
+    <exclusiveGateway id="NeedClarification"/>
+    <sequenceFlow id="flow2" sourceRef="AnalyseQuery" targetRef="NeedClarification"/>
+    <sequenceFlow id="flow3" sourceRef="NeedClarification" targetRef="AskUser">
+      <conditionExpression xsi:type="tFormalExpression"><![CDATA[${questions}]]></conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id="flow4" sourceRef="NeedClarification" targetRef="QueryExtender" default="true"/>
+
+    <serviceTask id="AskUser" name="Ask User Questions"
+                 camunda:expression="${ask_questions(questions)}">
+      <extensionElements>
+        <ext:operation name="ask_questions">
+          <ext:in name="questions"/>
+          <ext:out name="clarifications"/>
+        </ext:operation>
+      </extensionElements>
+    </serviceTask>
+    <sequenceFlow id="flow5" sourceRef="AskUser" targetRef="QueryExtender"/>
+
+    <serviceTask id="QueryExtender" name="Query Extender"
+                 camunda:expression="${query_extender(query, clarifications, next_query)}">
+      <extensionElements>
+        <ext:operation name="query_extender">
+          <ext:in name="query"/>
+          <ext:in name="clarifications"/>
+          <ext:in name="next_query"/>
+          <ext:out name="extended_query"/>
+        </ext:operation>
+      </extensionElements>
+    </serviceTask>
+    <sequenceFlow id="flow6" sourceRef="QueryExtender" targetRef="Retrieve"/>
+
+    <serviceTask id="Retrieve" name="Retrieve"
+                 camunda:expression="${retrieve_from_web(extended_query)}">
+      <extensionElements>
+        <ext:operation name="retrieve_from_web">
+          <ext:in name="extended_query"/>
+          <ext:out name="chunks"/>
+        </ext:operation>
+      </extensionElements>
+    </serviceTask>
+    <sequenceFlow id="flow7" sourceRef="Retrieve" targetRef="ProcessInfo"/>
+
+    <serviceTask id="ProcessInfo" name="Process Info"
+                 camunda:expression="${process_info(query, chunks, answer_draft)}">
+      <extensionElements>
+        <ext:operation name="process_info">
+          <ext:in name="query"/>
+          <ext:in name="chunks"/>
+          <ext:in name="answer_draft"/>
+          <ext:out name="answer_draft"/>
+        </ext:operation>
+      </extensionElements>
+    </serviceTask>
+    <sequenceFlow id="flow8" sourceRef="ProcessInfo" targetRef="AnswerValidate"/>
+
+    <serviceTask id="AnswerValidate" name="Answer Validate"
+                 camunda:expression="${answer_validate(answer_draft)}">
+      <extensionElements>
+        <ext:operation name="answer_validate">
+          <ext:in name="answer_draft"/>
+          <ext:out name="is_enough"/>
+          <ext:out name="next_query"/>
+        </ext:operation>
+      </extensionElements>
+    </serviceTask>
+    <sequenceFlow id="flow9" sourceRef="AnswerValidate" targetRef="DecisionValidate"/>
+
+    <exclusiveGateway id="DecisionValidate"/>
+    <sequenceFlow id="flow10" sourceRef="DecisionValidate" targetRef="FinalAnswer">
+      <conditionExpression xsi:type="tFormalExpression"><![CDATA[${is_enough == 'GOOD' or iteration >= 10}]]></conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id="flow11" sourceRef="DecisionValidate" targetRef="QueryExtender" default="true"/>
+
+    <serviceTask id="FinalAnswer" name="Final Answer"
+                 camunda:expression="${final_answer_generation(query, answer_draft)}">
+      <extensionElements>
+        <ext:operation name="final_answer_generation">
+          <ext:in name="query"/>
+          <ext:in name="answer_draft"/>
+          <ext:out name="final_answer"/>
+        </ext:operation>
+      </extensionElements>
+    </serviceTask>
+    <sequenceFlow id="flow12" sourceRef="FinalAnswer" targetRef="End"/>
+
+    <endEvent id="End"/>
+  </process>
+  <bpmndi:BPMNDiagram id="Diagram_1" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI">
+    <bpmndi:BPMNPlane id="Plane_1" bpmnElement="DeepResearch">
+      <bpmndi:BPMNShape id="Start_di" bpmnElement="Start">
+        <omgdc:Bounds x="100" y="100" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Analyse_di" bpmnElement="AnalyseQuery">
+        <omgdc:Bounds x="200" y="80" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="NeedClarification_di" bpmnElement="NeedClarification">
+        <omgdc:Bounds x="350" y="95" width="50" height="50"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="AskUser_di" bpmnElement="AskUser">
+        <omgdc:Bounds x="350" y="200" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="QueryExtender_di" bpmnElement="QueryExtender">
+        <omgdc:Bounds x="500" y="80" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Retrieve_di" bpmnElement="Retrieve">
+        <omgdc:Bounds x="650" y="80" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ProcessInfo_di" bpmnElement="ProcessInfo">
+        <omgdc:Bounds x="800" y="80" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="AnswerValidate_di" bpmnElement="AnswerValidate">
+        <omgdc:Bounds x="950" y="80" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DecisionValidate_di" bpmnElement="DecisionValidate">
+        <omgdc:Bounds x="1100" y="95" width="50" height="50"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="FinalAnswer_di" bpmnElement="FinalAnswer">
+        <omgdc:Bounds x="1250" y="80" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="End_di" bpmnElement="End">
+        <omgdc:Bounds x="1400" y="100" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="flow1_di" bpmnElement="flow1"><omgdi:waypoint x="136" y="118"/><omgdi:waypoint x="200" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow2_di" bpmnElement="flow2"><omgdi:waypoint x="300" y="118"/><omgdi:waypoint x="350" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow3_di" bpmnElement="flow3"><omgdi:waypoint x="375" y="118"/><omgdi:waypoint x="350" y="240"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow4_di" bpmnElement="flow4"><omgdi:waypoint x="375" y="118"/><omgdi:waypoint x="500" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow5_di" bpmnElement="flow5"><omgdi:waypoint x="450" y="240"/><omgdi:waypoint x="500" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow6_di" bpmnElement="flow6"><omgdi:waypoint x="600" y="118"/><omgdi:waypoint x="650" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow7_di" bpmnElement="flow7"><omgdi:waypoint x="750" y="118"/><omgdi:waypoint x="800" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow8_di" bpmnElement="flow8"><omgdi:waypoint x="900" y="118"/><omgdi:waypoint x="950" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow9_di" bpmnElement="flow9"><omgdi:waypoint x="1050" y="118"/><omgdi:waypoint x="1100" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow10_di" bpmnElement="flow10"><omgdi:waypoint x="1125" y="118"/><omgdi:waypoint x="1250" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow11_di" bpmnElement="flow11"><omgdi:waypoint x="1125" y="118"/><omgdi:waypoint x="500" y="118"/></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="flow12_di" bpmnElement="flow12"><omgdi:waypoint x="1350" y="118"/><omgdi:waypoint x="1400" y="118"/></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
## Summary
- add `deepresearch` BPMN workflow implementing research cycle logic
- stub out functions for deepresearch tasks
- generate extension schema for deepresearch workflow
- include tests covering successful run and iterative loop

## Testing
- `pip install -r requirements.txt`
- `python validate_workflow.py workflows/deepresearch/deepresearch.xml --functions steps.deepresearch_functions`
- `pytest -q` *(fails: initdb cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_6857ba47bbc4833299b5fb0b45317195