### PR TITLE
Add loop limit test

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -9,6 +9,7 @@ def run_workflow(
     checkpointer=None,
     thread_id="test",
     interrupt_after=None,
+    recursion_limit=100,
 ):
     fn_map = {
         name: getattr(wf, name)
@@ -21,7 +22,7 @@ def run_workflow(
     input_kwargs = {"input_text": "hello", "rephraseCount": 0}
     if params:
         input_kwargs.update(params)
-    config = {"configurable": {"thread_id": thread_id}}
+    config = {"configurable": {"thread_id": thread_id}, "recursion_limit": recursion_limit}
     return app.invoke(
         input_kwargs,
         config,


### PR DESCRIPTION
## Summary
- add configurable recursion_limit to test helper
- check that the deep research workflow performs exactly 10 cycles when validation never passes

## Testing
- `pytest tests/test_deepresearch.py::test_deepresearch_max_iterations -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68580d626178833299047ea58974e847