### PR TITLE
Add interrupt for user questions in deep research workflow

### DIFF
--- a/steps/deepresearch_functions.py
+++ b/steps/deepresearch_functions.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 from llama_index.llms.ollama import Ollama
 from llama_index.core.llms import ChatMessage
 from bpmn_ext.bpmn_ext import bpmn_op
+from langgraph.types import interrupt
 
 PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "deepresearch.yaml"
 
@@ -53,7 +54,9 @@ def analyse_user_query(state: Dict[str, Any]) -> Dict[str, Any]:
     outputs={"clarifications": str},
 )
 def ask_questions(state: Dict[str, Any]) -> Dict[str, Any]:
-    return {"clarifications": "clarified"}
+    questions = state.get("questions", [])
+    answer = interrupt({"questions": questions})
+    return {"clarifications": answer}
 
 @bpmn_op(
     name="query_extender",

--- a/tests/test_deepresearch_questions.py
+++ b/tests/test_deepresearch_questions.py
@@ -1,0 +1,27 @@
+import steps.deepresearch_functions as drf
+from run_bpmn_workflow import build_graph
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.types import Command
+
+XML_PATH = "workflows/deepresearch/deepresearch.xml"
+
+FN_MAP = {name: getattr(drf, name) for name in dir(drf) if not name.startswith("_")}
+
+def test_clarification_interrupt_resume():
+    def analyse(state):
+        return {"extended_query": state.get("query", ""), "questions": ["clarify?"]}
+
+    overrides = dict(FN_MAP)
+    overrides["analyse_user_query"] = analyse
+
+    saver = MemorySaver()
+    graph = build_graph(XML_PATH, functions=overrides, checkpointer=saver)
+
+    config = {"configurable": {"thread_id": "clarify"}}
+
+    first = graph.invoke({"query": "hello"}, config)
+    assert "__interrupt__" in first
+
+    resumed = graph.invoke(Command(resume="answer"), config)
+    assert resumed.get("clarifications") == "answer"
+    assert resumed.get("final_answer")


### PR DESCRIPTION
## Summary
- implement interrupt/resume logic for `ask_questions` step
- add regression test for pausing and resuming clarification step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68583706be708332a5cfd5fe0a0bcddb