### PR TITLE
Refactor iteration handling using BPMN loop metadata

### DIFF
--- a/steps/deepresearch_functions.py
+++ b/steps/deepresearch_functions.py
@@ -64,7 +64,6 @@ def ask_questions(state: Dict[str, Any]) -> Dict[str, Any]:
     outputs={"extended_query": str},
 )
 def query_extender(state: Dict[str, Any]) -> Dict[str, Any]:
-    state["iteration"] = state.get("iteration", 0) + 1
     return {"extended_query": state.get("next_query") or state.get("query", "")}
 
 @bpmn_op(

--- a/workflows/deepresearch/deepresearch.xml
+++ b/workflows/deepresearch/deepresearch.xml
@@ -38,60 +38,70 @@
     </serviceTask>
     <sequenceFlow id="flow5" sourceRef="AskUser" targetRef="QueryExtender"/>
 
-    <serviceTask id="QueryExtender" name="Query Extender"
-                 camunda:expression="${query_extender(query, clarifications, next_query)}">
-      <extensionElements>
-        <ext:operation name="query_extender">
-          <ext:in name="query"/>
-          <ext:in name="clarifications"/>
-          <ext:in name="next_query"/>
-          <ext:out name="extended_query"/>
-        </ext:operation>
-      </extensionElements>
-    </serviceTask>
-    <sequenceFlow id="flow6" sourceRef="QueryExtender" targetRef="Retrieve"/>
+    <subProcess id="ResearchLoop">
+      <multiInstanceLoopCharacteristics isSequential="true">
+        <loopCardinality xsi:type="tFormalExpression">10</loopCardinality>
+      </multiInstanceLoopCharacteristics>
 
-    <serviceTask id="Retrieve" name="Retrieve"
-                 camunda:expression="${retrieve_from_web(extended_query)}">
-      <extensionElements>
-        <ext:operation name="retrieve_from_web">
-          <ext:in name="extended_query"/>
-          <ext:out name="chunks"/>
-        </ext:operation>
-      </extensionElements>
-    </serviceTask>
-    <sequenceFlow id="flow7" sourceRef="Retrieve" targetRef="ProcessInfo"/>
+      <startEvent id="LoopStart" />
+      <sequenceFlow id="flow5a" sourceRef="LoopStart" targetRef="QueryExtender"/>
 
-    <serviceTask id="ProcessInfo" name="Process Info"
-                 camunda:expression="${process_info(query, chunks, answer_draft)}">
-      <extensionElements>
-        <ext:operation name="process_info">
-          <ext:in name="query"/>
-          <ext:in name="chunks"/>
-          <ext:in name="answer_draft"/>
-          <ext:out name="answer_draft"/>
-        </ext:operation>
-      </extensionElements>
-    </serviceTask>
-    <sequenceFlow id="flow8" sourceRef="ProcessInfo" targetRef="AnswerValidate"/>
+      <serviceTask id="QueryExtender" name="Query Extender"
+                   camunda:expression="${query_extender(query, clarifications, next_query)}">
+        <extensionElements>
+          <ext:operation name="query_extender">
+            <ext:in name="query"/>
+            <ext:in name="clarifications"/>
+            <ext:in name="next_query"/>
+            <ext:out name="extended_query"/>
+          </ext:operation>
+        </extensionElements>
+      </serviceTask>
+      <sequenceFlow id="flow6" sourceRef="QueryExtender" targetRef="Retrieve"/>
 
-    <serviceTask id="AnswerValidate" name="Answer Validate"
-                 camunda:expression="${answer_validate(answer_draft)}">
-      <extensionElements>
-        <ext:operation name="answer_validate">
-          <ext:in name="answer_draft"/>
-          <ext:out name="is_enough"/>
-          <ext:out name="next_query"/>
-        </ext:operation>
-      </extensionElements>
-    </serviceTask>
-    <sequenceFlow id="flow9" sourceRef="AnswerValidate" targetRef="DecisionValidate"/>
+      <serviceTask id="Retrieve" name="Retrieve"
+                   camunda:expression="${retrieve_from_web(extended_query)}">
+        <extensionElements>
+          <ext:operation name="retrieve_from_web">
+            <ext:in name="extended_query"/>
+            <ext:out name="chunks"/>
+          </ext:operation>
+        </extensionElements>
+      </serviceTask>
+      <sequenceFlow id="flow7" sourceRef="Retrieve" targetRef="ProcessInfo"/>
 
-    <exclusiveGateway id="DecisionValidate"/>
-    <sequenceFlow id="flow10" sourceRef="DecisionValidate" targetRef="FinalAnswer">
-      <conditionExpression xsi:type="tFormalExpression"><![CDATA[${is_enough == 'GOOD' or iteration >= 10}]]></conditionExpression>
-    </sequenceFlow>
-    <sequenceFlow id="flow11" sourceRef="DecisionValidate" targetRef="QueryExtender" default="true"/>
+      <serviceTask id="ProcessInfo" name="Process Info"
+                   camunda:expression="${process_info(query, chunks, answer_draft)}">
+        <extensionElements>
+          <ext:operation name="process_info">
+            <ext:in name="query"/>
+            <ext:in name="chunks"/>
+            <ext:in name="answer_draft"/>
+            <ext:out name="answer_draft"/>
+          </ext:operation>
+        </extensionElements>
+      </serviceTask>
+      <sequenceFlow id="flow8" sourceRef="ProcessInfo" targetRef="AnswerValidate"/>
+
+      <serviceTask id="AnswerValidate" name="Answer Validate"
+                   camunda:expression="${answer_validate(answer_draft)}">
+        <extensionElements>
+          <ext:operation name="answer_validate">
+            <ext:in name="answer_draft"/>
+            <ext:out name="is_enough"/>
+            <ext:out name="next_query"/>
+          </ext:operation>
+        </extensionElements>
+      </serviceTask>
+      <sequenceFlow id="flow9" sourceRef="AnswerValidate" targetRef="DecisionValidate"/>
+
+      <exclusiveGateway id="DecisionValidate"/>
+      <sequenceFlow id="flow10" sourceRef="DecisionValidate" targetRef="FinalAnswer">
+        <conditionExpression xsi:type="tFormalExpression"><![CDATA[${is_enough == 'GOOD'}]]></conditionExpression>
+      </sequenceFlow>
+      <sequenceFlow id="flow11" sourceRef="DecisionValidate" targetRef="QueryExtender" default="true"/>
+    </subProcess>
+
 
     <serviceTask id="FinalAnswer" name="Final Answer"
                  camunda:expression="${final_answer_generation(query, answer_draft)}">


### PR DESCRIPTION
## Summary
- add support for BPMN subprocess loops in `run_bpmn_workflow.py`
- increment loop counters generically when entering loop start nodes
- stop looping when loop cardinality is reached
- remove manual iteration update from `query_extender`
- define iterative subprocess in `deepresearch.xml`

## Testing
- `ruff check run_bpmn_workflow.py steps/deepresearch_functions.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68590323301083329a980ec575331c5c