### PR TITLE
Implement query extender

### DIFF
--- a/prompts/deepresearch.yaml
+++ b/prompts/deepresearch.yaml
@@ -6,3 +6,13 @@ analyse_user_query: |
   Respond in JSON with two keys:
     extended_query: revised query text
     questions: list of questions, leave empty if none are needed
+
+query_extender: |
+  You are extending a search query for iterative research.
+  Original query: "{query}"
+  User clarifications: "{clarifications}"
+  Current research focus: "{next_query}"
+  Craft a single concise search query for the next iteration.
+  Prioritize the current focus and incorporate clarifications and the original query when helpful.
+  Respond in JSON with one key:
+    extended_query: the rewritten query

--- a/tests/test_query_extender.py
+++ b/tests/test_query_extender.py
@@ -1,0 +1,29 @@
+import steps.deepresearch_functions as drf
+
+
+def test_query_extender_fallback(monkeypatch):
+    class Dummy:
+        def chat(self, msgs):
+            raise RuntimeError("fail")
+
+    monkeypatch.setattr(drf, "_structured_llm_extender", lambda: Dummy())
+    res = drf.query_extender({
+        "query": "base",
+        "clarifications": "details",
+        "next_query": "direction",
+    })
+    assert "direction" in res["extended_query"]
+    assert "details" in res["extended_query"]
+
+
+def test_query_extender_llm(monkeypatch):
+    class Dummy:
+        def chat(self, msgs):
+            class R:
+                raw = drf.QueryExtension(extended_query="from llm")
+            return R()
+
+    monkeypatch.setattr(drf, "_structured_llm_extender", lambda: Dummy())
+    res = drf.query_extender({"query": "base", "clarifications": "", "next_query": ""})
+    assert res["extended_query"] == "from llm"
+


### PR DESCRIPTION
## Summary
- implement query_extender step using LlamaIndex structured output
- add prompts for query_extender
- add tests for the new behaviour

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a6d697c08332b8e72c6960c2854e