### PR TITLE
Add LLM-based info processing

### DIFF
--- a/prompts/deepresearch.yaml
+++ b/prompts/deepresearch.yaml
@@ -16,3 +16,15 @@ query_extender: |
   Prioritize the current focus and incorporate clarifications and the original query when helpful.
   Respond in JSON with one key:
     extended_query: the rewritten query
+
+process_info: |
+  You are compiling research information to answer a user question.
+  Original query: "{query}"
+  Extended query used for retrieval: "{extended_query}"
+  Current draft answer:
+    {answer_draft}
+  Retrieved chunks:
+    {chunks}
+  Combine the chunks with the existing draft to produce an updated answer.
+  Respond in JSON with one key:
+    answer_draft: the updated draft answer

--- a/tests/test_process_info.py
+++ b/tests/test_process_info.py
@@ -1,0 +1,35 @@
+import steps.deepresearch_functions as drf
+
+
+def test_process_info_fallback(monkeypatch):
+    class Dummy:
+        def chat(self, msgs):
+            raise RuntimeError("fail")
+
+    monkeypatch.setattr(drf, "_structured_llm_draft", lambda: Dummy())
+    res = drf.process_info({
+        "query": "q",
+        "extended_query": "ex",
+        "chunks": ["c1"],
+        "answer_draft": "prev",
+    })
+    assert res["answer_draft"].startswith("prev")
+    assert "c1" in res["answer_draft"]
+
+
+def test_process_info_llm(monkeypatch):
+    class Dummy:
+        def chat(self, msgs):
+            class R:
+                raw = drf.AnswerDraft(answer_draft="from llm")
+
+            return R()
+
+    monkeypatch.setattr(drf, "_structured_llm_draft", lambda: Dummy())
+    res = drf.process_info({
+        "query": "q",
+        "extended_query": "ex",
+        "chunks": ["c1"],
+        "answer_draft": "prev",
+    })
+    assert res["answer_draft"] == "from llm"


### PR DESCRIPTION
## Summary
- implement structured process_info step using Ollama
- add prompt for process_info
- add unit tests for fallback and LLM paths

## Testing
- `ruff check --fix tests/test_process_info.py steps/deepresearch_functions.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ba10a5a6c83328dae4e0956855812