### PR TITLE
Implement answer validation with LLM

### DIFF
--- a/prompts/deepresearch.yaml
+++ b/prompts/deepresearch.yaml
@@ -28,3 +28,12 @@ process_info: |
   Combine the chunks with the existing draft to produce an updated answer.
   Respond in JSON with one key:
     answer_draft: the updated draft answer
+
+answer_validate: |
+  You are assessing whether the current draft fully answers the user request.
+  User query: "{query}"
+  Draft answer:
+    {answer_draft}
+  Decide if the answer is sufficient. Respond in JSON with two keys:
+    is_enough: either GOOD or BAD
+    next_query: if BAD, provide a concise follow-up query to continue research, otherwise empty

--- a/tests/test_answer_validate.py
+++ b/tests/test_answer_validate.py
@@ -1,0 +1,26 @@
+import steps.deepresearch_functions as drf
+
+
+def test_answer_validate_fallback(monkeypatch):
+    class Dummy:
+        def chat(self, msgs):
+            raise RuntimeError("fail")
+
+    monkeypatch.setattr(drf, "_structured_llm_validate", lambda: Dummy())
+    res = drf.answer_validate({"query": "q", "answer_draft": "draft"})
+    assert res["is_enough"] == "BAD"
+    assert res["next_query"]
+
+
+def test_answer_validate_llm(monkeypatch):
+    class Dummy:
+        def chat(self, msgs):
+            class R:
+                raw = drf.AnswerValidation(is_enough="GOOD", next_query="")
+
+            return R()
+
+    monkeypatch.setattr(drf, "_structured_llm_validate", lambda: Dummy())
+    res = drf.answer_validate({"query": "q", "answer_draft": "draft"})
+    assert res["is_enough"] == "GOOD"
+    assert res["next_query"] == ""


### PR DESCRIPTION
## Summary
- add `AnswerValidation` model and LLM wrapper
- implement `answer_validate` to use Ollama structured LLM with fallback
- provide prompt for answer validation
- add unit tests for new function

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ba81993388332903878d4b01a3eea