### PR TITLE
Implement final answer step

### DIFF
--- a/prompts/deepresearch.yaml
+++ b/prompts/deepresearch.yaml
@@ -37,3 +37,12 @@ answer_validate: |
   Decide if the answer is sufficient. Respond in JSON with two keys:
     is_enough: either GOOD or BAD
     next_query: if BAD, provide a concise follow-up query to continue research, otherwise empty
+
+final_answer_generation: |
+  You are polishing the final answer for a user.
+  Original query: "{query}"
+  Current draft answer:
+    {answer_draft}
+  Refine the draft into a clear and complete response.
+  Respond in JSON with one key:
+    final_answer: the polished answer

--- a/tests/test_deepresearch_mocked_llms.py
+++ b/tests/test_deepresearch_mocked_llms.py
@@ -1,0 +1,50 @@
+from .helper import run_workflow
+import steps.deepresearch_functions as drf
+
+XML_PATH = "workflows/deepresearch/deepresearch.xml"
+
+FN_MAP = {name: getattr(drf, name) for name in dir(drf) if not name.startswith("_")}
+
+
+def test_deepresearch_full_mocked(monkeypatch):
+    class DummyAnalyse:
+        def chat(self, msgs):
+            class R:
+                raw = drf.QueryAnalysis(extended_query="ext", questions=[])
+            return R()
+
+    class DummyExtender:
+        def chat(self, msgs):
+            class R:
+                raw = drf.QueryExtension(extended_query="ext q")
+            return R()
+
+    class DummyDraft:
+        def chat(self, msgs):
+            class R:
+                raw = drf.AnswerDraft(answer_draft="draft")
+            return R()
+
+    class DummyValidate:
+        def chat(self, msgs):
+            class R:
+                raw = drf.AnswerValidation(is_enough="GOOD", next_query="")
+            return R()
+
+    class DummyFinal:
+        def chat(self, msgs):
+            class R:
+                raw = drf.FinalAnswer(final_answer="polished")
+            return R()
+
+    monkeypatch.setattr(drf, "_structured_llm", lambda: DummyAnalyse())
+    monkeypatch.setattr(drf, "_structured_llm_extender", lambda: DummyExtender())
+    monkeypatch.setattr(drf, "_structured_llm_draft", lambda: DummyDraft())
+    monkeypatch.setattr(drf, "_structured_llm_validate", lambda: DummyValidate())
+    monkeypatch.setattr(drf, "_structured_llm_final", lambda: DummyFinal())
+
+    # avoid network access during retrieval
+    monkeypatch.setattr(drf, "retrieve_from_web", lambda state: {"chunks": ["chunk"]})
+
+    result = run_workflow(XML_PATH, fn_overrides=FN_MAP, params={"query": "hello"})
+    assert result.get("final_answer") == "polished"

--- a/tests/test_final_answer_generation.py
+++ b/tests/test_final_answer_generation.py
@@ -1,0 +1,24 @@
+import steps.deepresearch_functions as drf
+
+
+def test_final_answer_generation_fallback(monkeypatch):
+    class Dummy:
+        def chat(self, msgs):
+            raise RuntimeError("fail")
+
+    monkeypatch.setattr(drf, "_structured_llm_final", lambda: Dummy())
+    res = drf.final_answer_generation({"query": "q", "answer_draft": "draft"})
+    assert res["final_answer"] == "draft"
+
+
+def test_final_answer_generation_llm(monkeypatch):
+    class Dummy:
+        def chat(self, msgs):
+            class R:
+                raw = drf.FinalAnswer(final_answer="from llm")
+
+            return R()
+
+    monkeypatch.setattr(drf, "_structured_llm_final", lambda: Dummy())
+    res = drf.final_answer_generation({"query": "q", "answer_draft": "draft"})
+    assert res["final_answer"] == "from llm"


### PR DESCRIPTION
## Summary
- add `final_answer_generation` LLM step in `deepresearch_functions`
- support final answer prompt in `deepresearch.yaml`
- test the final answer generation function
- test the full deepresearch flow with mocked LLMs

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bad3de5548332883d3b6aebb5a102