### PR TITLE
Add FastAPI backend

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ['app']
+from .main import app
+

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,23 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base, Session
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
+)
+
+engine = create_engine(DATABASE_URL, echo=False, future=True)
+SessionLocal = sessionmaker(bind=engine)
+
+Base = declarative_base()
+
+def init_db() -> None:
+    Base.metadata.create_all(engine)
+
+def get_session() -> Session:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+import os
+import uuid
+
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+import uvicorn
+
+import steps.deepresearch_functions as drf
+from bpmn_workflows.run_bpmn_workflow import run_workflow
+from langgraph.checkpoint.postgres import PostgresSaver
+
+from .database import init_db, get_session
+from .models import WorkflowRun
+from .workflows import list_templates, get_template
+
+POSTGRES_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql+psycopg://postgres:postgres@localhost:5432/postgres",
+)
+
+FN_MAP = {name: getattr(drf, name) for name in dir(drf) if not name.startswith("_")}
+
+app = FastAPI()
+
+
+@app.on_event("startup")
+def startup() -> None:
+    init_db()
+
+
+@app.get("/workflow-templates")
+def templates() -> list[dict[str, str]]:
+    return list_templates()
+
+
+@app.get("/workflows")
+def workflows_history(db: Session = Depends(get_session)) -> list[dict[str, str]]:
+    result = db.execute(select(WorkflowRun))
+    runs = result.scalars().all()
+    return [
+        {"id": r.id, "template": r.template, "status": r.status, "created_at": r.created_at}
+        for r in runs
+    ]
+
+
+@app.get("/workflows/{workflow_id}")
+def workflow_detail(workflow_id: str, db: Session = Depends(get_session)) -> dict:
+    run = db.get(WorkflowRun, workflow_id)
+    if not run:
+        raise HTTPException(404, "Workflow not found")
+    return {
+        "id": run.id,
+        "template": run.template,
+        "status": run.status,
+        "result": run.result,
+    }
+
+
+def _run_flow(xml_path: str, params: dict | None, thread_id: str, resume: str | None = None) -> dict:
+    with PostgresSaver.from_conn_string(POSTGRES_URL) as saver:
+        saver.setup()
+        return run_workflow(
+            xml_path,
+            fn_map=FN_MAP,
+            params=params,
+            thread_id=thread_id,
+            resume=resume,
+            checkpointer=saver,
+        )
+
+
+@app.post("/workflows")
+def start_workflow(
+    data: dict,
+    db: Session = Depends(get_session),
+) -> dict:
+    identifier = data.get("template_name") or data.get("template_id")
+    query = data.get("query", "")
+    tpl = get_template(identifier)
+    if not tpl:
+        raise HTTPException(404, "Template not found")
+    workflow_id = str(uuid.uuid4())
+    result = _run_flow(tpl["path"], {"query": query}, workflow_id)
+    status = "WAITING" if "__interrupt__" in result else "COMPLETED"
+    run = WorkflowRun(
+        id=workflow_id,
+        template=tpl["id"],
+        thread_id=workflow_id,
+        status=status,
+        query=query,
+        result=result,
+    )
+    db.add(run)
+    db.commit()
+    db.refresh(run)
+    return {"id": run.id, "status": run.status, "result": result}
+
+
+@app.post("/workflows/{workflow_id}/continue")
+def continue_workflow(
+    workflow_id: str,
+    data: dict,
+    db: Session = Depends(get_session),
+) -> dict:
+    run = db.get(WorkflowRun, workflow_id)
+    if not run:
+        raise HTTPException(404, "Workflow not found")
+    query = data.get("query", "")
+    tpl = get_template(run.template)
+    resume_payload = json.dumps({"answer": query})
+    result = _run_flow(tpl["path"], None, workflow_id, resume=resume_payload)
+    run.status = "WAITING" if "__interrupt__" in result else "COMPLETED"
+    run.result = result
+    db.commit()
+    db.refresh(run)
+    return {"id": run.id, "status": run.status, "result": result}
+
+
+if __name__ == "__main__":
+    uvicorn.run("backend.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, String, DateTime, Text, JSON
+from sqlalchemy.sql import func
+import uuid
+
+from .database import Base
+
+class WorkflowRun(Base):
+    __tablename__ = "workflow_runs"
+
+    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    template = Column(String, nullable=False)
+    thread_id = Column(String, nullable=False, unique=True)
+    status = Column(String, nullable=False)
+    query = Column(Text, nullable=True)
+    result = Column(JSON, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/workflows.py
+++ b/backend/workflows.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from typing import List, Dict
+
+WORKFLOWS_DIR = Path(__file__).resolve().parent.parent / "workflows"
+
+
+def list_templates() -> List[Dict[str, str]]:
+    templates: List[Dict[str, str]] = []
+    for xml in WORKFLOWS_DIR.glob("**/*.xml"):
+        templates.append({"id": xml.stem, "name": xml.stem, "path": str(xml)})
+    return templates
+
+
+def get_template(identifier: str | None) -> Dict[str, str] | None:
+    if not identifier:
+        return None
+    for tpl in list_templates():
+        if tpl["id"] == identifier or tpl["name"] == identifier:
+            return tpl
+    return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ networkx
 langgraph>=0.4
 langgraph-checkpoint-postgres
 psycopg[binary]
+SQLAlchemy>=2.0
 xmlschema
 pytest
 testing.postgresql

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,32 @@
+import os
+import tempfile
+from fastapi.testclient import TestClient
+
+# use temporary sqlite db for tests
+fd, path = tempfile.mkstemp()
+os.close(fd)
+os.environ["DATABASE_URL"] = f"sqlite:///{path}"
+
+from backend import main  # noqa: E402
+
+
+def dummy_run(*args, **kwargs):
+    return {"final_answer": "answer"}
+
+
+def test_templates():
+    with TestClient(main.app) as client:
+        resp = client.get("/workflow-templates")
+        assert resp.status_code == 200
+        assert any(t["id"] == "deepresearch" for t in resp.json())
+
+
+def test_start_and_continue(monkeypatch):
+    monkeypatch.setattr(main, "_run_flow", lambda *a, **k: {"final_answer": "answer"})
+    with TestClient(main.app) as client:
+        start = client.post("/workflows", json={"template_id": "deepresearch", "query": "hi"})
+        assert start.status_code == 200
+        wf_id = start.json()["id"]
+        cont = client.post(f"/workflows/{wf_id}/continue", json={"query": "ok"})
+        assert cont.status_code == 200
+        assert cont.json()["result"]["final_answer"] == "answer"


### PR DESCRIPTION
## Summary
- add basic FastAPI backend with workflow management endpoints
- manage workflow runs in PostgreSQL or SQLite
- expose utility to list workflow templates and execute workflows
- create automated tests for the backend
- update requirements with SQLAlchemy

## Testing
- `ruff check backend tests/test_backend.py --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68603db631c8833284020c6926008d36