### PR TITLE
Add Jest unit tests for frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@ __pycache__/
 .env
 .chainlit
 
+*/node_modules/
+frontend/package-lock.json
+
 .DS_Store

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,0 +1,3 @@
+export default {
+  presets: ['@babel/preset-env', ['@babel/preset-react', {runtime: 'automatic'}]],
+};

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,10 @@
+export default {
+  testEnvironment: 'jest-environment-jsdom',
+  transform: {
+    '^.+\\.(js|jsx)$': 'babel-jest'
+  },
+  moduleNameMapper: {
+    '\\.(css)$': 'identity-obj-proxy'
+  },
+  moduleFileExtensions: ['js', 'jsx'],
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,21 +7,30 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.27.2",
+    "@babel/preset-react": "^7.27.1",
     "@eslint/js": "^9.29.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.2",
+    "babel-jest": "^30.0.2",
     "eslint": "^9.29.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.2.0",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^30.0.3",
+    "jest-environment-jsdom": "^30.0.2",
     "vite": "^7.0.0"
   }
 }

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,0 +1,95 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App from './App';
+
+beforeEach(() => {
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+function mockResponse(data) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(data) });
+}
+
+test('workflows display in finished, in progress and waiting states', async () => {
+  fetch.mockImplementation((url) => {
+    if (url === '/workflows') {
+      return mockResponse([
+        { id: '1', template: 'a', status: 'in progress' },
+        { id: '2', template: 'b', status: 'waiting for user' },
+        { id: '3', template: 'c', status: 'finished' }
+      ]);
+    }
+    return mockResponse({ id: '1', template: 'a', status: 'in progress', result: {} });
+  });
+
+  render(<App />);
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledWith('/workflows'));
+  await screen.findAllByRole('listitem');
+
+  expect(document.querySelector('.state-in-progress')).toBeTruthy();
+  expect(document.querySelector('.state-waiting-for-user')).toBeTruthy();
+  expect(document.querySelector('.state-finished')).toBeTruthy();
+});
+
+test('user can start new workflow with query', async () => {
+  fetch.mockImplementation((url, options) => {
+    if (url === '/workflows' && !options) {
+      return mockResponse([]);
+    }
+    if (url === '/workflows' && options?.method === 'POST') {
+      return mockResponse({ id: '10', template: 'deepresearch', status: 'in progress', result: {} });
+    }
+    if (url === '/workflows/10') {
+      return mockResponse({ id: '10', template: 'deepresearch', status: 'in progress', result: {} });
+    }
+    return mockResponse({});
+  });
+
+  jest.spyOn(window, 'prompt').mockReturnValue('my query');
+
+  render(<App />);
+
+  fireEvent.click(screen.getByText(/Start New Workflow/));
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledWith('/workflows', expect.objectContaining({ method: 'POST' })));
+
+  expect(await screen.findByText('in progress')).toBeInTheDocument();
+});
+
+test('user can continue waiting workflow', async () => {
+  fetch.mockImplementation((url, options) => {
+    if (url === '/workflows' && !options) {
+      return mockResponse([{ id: '5', template: 'deepresearch', status: 'waiting for user' }]);
+    }
+    if (url === '/workflows/5') {
+      return mockResponse({
+        id: '5',
+        template: 'deepresearch',
+        status: 'waiting for user',
+        result: { __interrupt__: [{ value: { questions: ['clarify?'] } }] }
+      });
+    }
+    if (url === '/workflows/5/continue') {
+      return mockResponse({ id: '5', template: 'deepresearch', status: 'finished', result: { final_answer: 'done' } });
+    }
+    return mockResponse({});
+  });
+
+  render(<App />);
+
+  await screen.findByText('waiting for user');
+  await screen.findByPlaceholderText('Answer');
+
+  fireEvent.change(screen.getByPlaceholderText('Answer'), { target: { value: 'ok' } });
+  fireEvent.click(screen.getByText('Continue'));
+
+  await waitFor(() => expect(fetch).toHaveBeenCalledWith('/workflows/5/continue', expect.objectContaining({ method: 'POST' })));
+
+  const elems = await screen.findAllByText('finished');
+  expect(elems.length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- ignore frontend dependencies
- configure Jest and Babel
- add unit tests for React app

## Testing
- `npm test` *(frontend)*
- `pytest -q` *(fails: No module named 'langgraph.checkpoint.postgres')*

------
https://chatgpt.com/codex/tasks/task_e_6862ef240cec8332b4ba31e8ec0d2696