### PR TITLE
Add background worker

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, DateTime, Text, JSON
+from sqlalchemy import Column, String, DateTime, Text, JSON, Integer
 from sqlalchemy.sql import func
 import uuid
 
@@ -8,10 +8,18 @@ class WorkflowRun(Base):
     __tablename__ = "workflow_runs"
 
     id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
-    template = Column(String, nullable=False)
+    graph_name = Column(String, nullable=False)
     thread_id = Column(String, nullable=False, unique=True)
-    status = Column(String, nullable=False)
+    state = Column(String, nullable=False, default="queued")
+    attempt = Column(Integer, nullable=False, default=0)
+    max_attempts = Column(Integer, nullable=False, default=3)
+    worker_id = Column(String, nullable=True)
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    heartbeat_at = Column(DateTime(timezone=True), nullable=True)
+    finished_at = Column(DateTime(timezone=True), nullable=True)
+    error = Column(Text, nullable=True)
     query = Column(Text, nullable=True)
+    resume_payload = Column(Text, nullable=True)
     result = Column(JSON, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -22,11 +22,10 @@ def test_templates():
 
 
 def test_start_and_continue(monkeypatch):
-    monkeypatch.setattr(main, "_run_flow", lambda *a, **k: {"final_answer": "answer"})
     with TestClient(main.app) as client:
-        start = client.post("/workflows", json={"template_id": "deepresearch", "query": "hi"})
+        start = client.post("/workflows", json={"template_name": "deepresearch", "query": "hi"})
         assert start.status_code == 200
         wf_id = start.json()["id"]
+        assert start.json()["status"] == "queued"
         cont = client.post(f"/workflows/{wf_id}/continue", json={"query": "ok"})
-        assert cont.status_code == 200
-        assert cont.json()["result"]["final_answer"] == "answer"
+        assert cont.status_code == 400  # cannot continue yet

--- a/worker/db.py
+++ b/worker/db.py
@@ -1,0 +1,85 @@
+import os
+import json
+import asyncio
+from typing import Any, Dict
+
+import asyncpg
+from langgraph.checkpoint.postgres import PostgresSaver
+
+from bpmn_workflows.run_bpmn_workflow import run_workflow
+from backend.workflow_loader import get_template
+import steps.deepresearch_functions as drf
+
+FN_MAP = {name: getattr(drf, name) for name in dir(drf) if not name.startswith("_")}
+
+async def claim_job(pool: asyncpg.pool.Pool, worker_id: str) -> Dict[str, Any] | None:
+    async with pool.acquire() as conn, conn.transaction():
+        row = await conn.fetchrow(
+            """
+            WITH next AS (
+                SELECT id
+                FROM workflow_runs
+                WHERE state = 'queued'
+                ORDER BY id
+                LIMIT 1
+                FOR UPDATE SKIP LOCKED
+            )
+            UPDATE workflow_runs
+            SET state='running',
+                worker_id = $1,
+                started_at = now(),
+                heartbeat_at = now(),
+                attempt = attempt + 1
+            FROM next
+            WHERE workflow_runs.id = next.id
+            RETURNING workflow_runs.*;
+            """,
+            worker_id,
+        )
+    return dict(row) if row else None
+
+async def set_state(
+    pool: asyncpg.pool.Pool,
+    job_id: str,
+    new_state: str,
+    result: Dict[str, Any] | None = None,
+    error: str | None = None,
+) -> None:
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            UPDATE workflow_runs
+            SET state = $2,
+                heartbeat_at = CASE WHEN $2='running' THEN now() ELSE heartbeat_at END,
+                finished_at = CASE WHEN $2 IN ('succeeded','failed') THEN now() END,
+                error = $3,
+                result = COALESCE($4, result)
+            WHERE id = $1
+            """,
+            job_id,
+            new_state,
+            error,
+            json.dumps(result) if result is not None else None,
+        )
+
+async def run_langgraph(job: Dict[str, Any]) -> tuple[str, Dict[str, Any]]:
+    tpl = get_template(job["graph_name"])
+    if not tpl:
+        raise ValueError("Template not found")
+    params = {"query": job.get("query", "")}
+    resume = job.get("resume_payload")
+    if resume:
+        params = None
+    with PostgresSaver.from_conn_string(os.getenv("DATABASE_URL")) as saver:
+        saver.setup()
+        result = await asyncio.to_thread(
+            run_workflow,
+            tpl["path"],
+            fn_map=FN_MAP,
+            params=params,
+            thread_id=job["id"],
+            resume=resume,
+            checkpointer=saver,
+        )
+    state = "needs_input" if "__interrupt__" in result else "succeeded"
+    return state, result

--- a/worker/worker_pool.py
+++ b/worker/worker_pool.py
@@ -1,0 +1,31 @@
+import asyncio
+import os
+import uuid
+import asyncpg
+
+from worker.db import claim_job, run_langgraph, set_state
+
+CONCURRENCY = int(os.getenv("WORKERS", 4))
+
+
+async def worker(pool: asyncpg.pool.Pool, wid: str) -> None:
+    while True:
+        job = await claim_job(pool, wid)
+        if job is None:
+            await asyncio.sleep(1)
+            continue
+        try:
+            new_state, result = await run_langgraph(job)
+            await set_state(pool, job["id"], new_state, result=result)
+        except Exception as exc:  # pragma: no cover - errors in worker
+            await set_state(pool, job["id"], "failed", error=str(exc))
+
+
+async def main() -> None:
+    pool = await asyncpg.create_pool(dsn=os.getenv("DATABASE_URL"))
+    tasks = [asyncio.create_task(worker(pool, f"w{uuid.uuid4()}")) for _ in range(CONCURRENCY)]
+    await asyncio.gather(*tasks)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- refactor WorkflowRun ORM to track execution state
- queue workflows in API instead of running synchronously
- add async worker pool using asyncpg to process queued runs
- adjust backend tests for queued workflow behaviour

## Testing
- `ruff check .`
- `pre-commit run --files backend/main.py backend/models.py tests/test_backend.py worker/db.py worker/worker_pool.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864ea4c20908332a90dab613354348f