### PR TITLE
Fix workflow start modal

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -511,9 +511,65 @@ body {
   .answer-input {
     flex-direction: column;
     align-items: stretch;
-  }
+}
 
-  .continue-btn {
-    width: 100%;
+.continue-btn {
+  width: 100%;
   }
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background-color: var(--card-background);
+  padding: 2rem;
+  border-radius: 12px;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.modal input,
+.modal select {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+
+.modal-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.modal-buttons .start-btn {
+  background-color: var(--primary-color);
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.modal-buttons .cancel-btn {
+  background-color: var(--secondary-color);
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -13,6 +13,15 @@ export async function getWorkflows() {
 }
 
 /**
+ * Fetch available workflow templates.
+ * @returns {Promise<TemplateInfo[]>}
+ */
+export async function getWorkflowTemplates() {
+  const resp = await fetch(`${BASE_URL}/workflow-templates`)
+  return resp.json()
+}
+
+/**
  * Fetch workflow details.
  * @param {string} id
  * @returns {Promise<WorkflowDetail>}


### PR DESCRIPTION
## Summary
- add ability to choose workflow template and query
- canceling the modal no longer starts workflow
- style the start modal
- add API helper for workflow templates
- expand frontend tests for these changes

## Testing
- `ruff check .`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866384bfd848332a57a38b77afd3899