### PR TITLE
Add periodic workflow refresh

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,6 +1,8 @@
 // Environment constants
 const {
-    VITE_API_BASE_URL,
+  VITE_API_BASE_URL,
+  VITE_POLL_INTERVAL_MS,
 } = import.meta.env;
 
-export const API_BASE_URL = VITE_API_BASE_URL || 'http://localhost:8000'; 
+export const API_BASE_URL = VITE_API_BASE_URL || 'http://localhost:8000';
+export const POLL_INTERVAL_MS = parseInt(VITE_POLL_INTERVAL_MS, 10) || 10000;

--- a/frontend/src/timer.js
+++ b/frontend/src/timer.js
@@ -1,0 +1,3 @@
+export function startPolling(callback, interval) {
+  return setInterval(callback, interval);
+}


### PR DESCRIPTION
## Summary
- poll workflow list regularly using a shared timer helper
- only poll selected workflow while in the running state
- mock timer in tests and add checks for polling behaviour

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6866d8906dac83329d12b1f56bd5b756