### PR TITLE
Add workflow cancelation support

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -141,6 +141,12 @@ body {
   border-color: #ef4444;
 }
 
+.state-canceled {
+  background-color: #e2e8f0;
+  color: #475569;
+  border-color: #94a3b8;
+}
+
 .new-workflow {
   width: 100%;
   padding: 0.875rem 1.25rem;
@@ -217,6 +223,11 @@ body {
 .status-failed {
   background-color: #fecaca;
   color: #991b1b;
+}
+
+.status-canceled {
+  background-color: #e2e8f0;
+  color: #475569;
 }
 
 /* Interrupt Section */

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import './App.css'
 import { continueWorkflow as apiContinue, startWorkflow as apiStart, getWorkflow, getWorkflows, getWorkflowTemplates } from './api.js'
+import { cancelWorkflow as apiCancel } from './api.js'
 import { POLL_INTERVAL_MS } from './constants.js'
 import { startPolling } from './timer.js'
 
@@ -95,6 +96,12 @@ export default function App() {
     setShowInterrupt(false)
   }
 
+  const cancelRunningWorkflow = async () => {
+    const data = await apiCancel(selectedId)
+    setWorkflows(workflows.map(w => (w.id === selectedId ? { ...w, status: data.status } : w)))
+    setSelected(data)
+  }
+
   const toggleSection = (section) => {
     setExpandedSections(prev => ({
       ...prev,
@@ -159,6 +166,9 @@ export default function App() {
               <span className={`status-badge status-${selected.status.replace(/[\s_]+/g, '-').toLowerCase()}`}>
                 {selected.status}
               </span>
+              {selected.status === 'running' && (
+                <button className="cancel-btn" onClick={cancelRunningWorkflow}>Cancel Workflow</button>
+              )}
             </div>
 
             {showInterrupt && interrupt ? (

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -60,3 +60,15 @@ export async function continueWorkflow(id, answer) {
   })
   return resp.json()
 }
+
+/**
+ * Cancel a running workflow.
+ * @param {string} id
+ * @returns {Promise<WorkflowResponse>}
+ */
+export async function cancelWorkflow(id) {
+  const resp = await fetch(`${BASE_URL}/workflows/${id}/cancel`, {
+    method: 'POST'
+  })
+  return resp.json()
+}

--- a/frontend/src/models.js
+++ b/frontend/src/models.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {'queued' | 'running' | 'needs_input' | 'failed' | 'succeeded'} WorkflowStatus
+ * @typedef {'queued' | 'running' | 'needs_input' | 'failed' | 'succeeded' | 'canceled'} WorkflowStatus
  */
 
 /**

--- a/readme.md
+++ b/readme.md
@@ -99,10 +99,11 @@ pytest -q
 ```
 
 **Node.js Tests:**
-Frontend tests are located in the `frontend/` directory and can be run using Jest:
+Frontend tests are located in the `frontend/` directory and can be run using Jest. Make sure to install dependencies first:
 
 ```bash
 cd frontend
+npm install
 npm test
 ```
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
 
 # use temporary sqlite db for tests
 fd, path = tempfile.mkstemp()
@@ -8,6 +9,8 @@ os.close(fd)
 os.environ["DATABASE_URL"] = f"sqlite:///{path}"
 
 from backend import main  # noqa: E402
+from backend.models import WorkflowRun  # noqa: E402
+from backend.database import SessionLocal  # noqa: E402
 
 
 def dummy_run(*args, **kwargs):
@@ -29,3 +32,22 @@ def test_start_and_continue(monkeypatch):
         assert start.json()["status"] == "queued"
         cont = client.post(f"/workflows/{wf_id}/continue", json={"query": "ok"})
         assert cont.status_code == 400  # cannot continue yet
+
+
+def test_cancel_workflow():
+    with TestClient(main.app) as client:
+        start = client.post("/workflows", json={"template_name": "deepresearch", "query": "hi"})
+        wf_id = start.json()["id"]
+        # set state to running
+        db: Session = SessionLocal()
+        run = db.get(WorkflowRun, wf_id)
+        run.state = main.WorkflowStatus.RUNNING
+        db.commit()
+        db.close()
+
+        cancel = client.post(f"/workflows/{wf_id}/cancel")
+        assert cancel.status_code == 200
+        assert cancel.json()["status"] == "canceled"
+
+        cont = client.post(f"/workflows/{wf_id}/continue", json={"query": "ok"})
+        assert cont.status_code == 400

--- a/worker/db.py
+++ b/worker/db.py
@@ -56,10 +56,10 @@ async def set_state(
             UPDATE workflow_runs
             SET state = $2::VARCHAR,
                 heartbeat_at = CASE WHEN $2::VARCHAR='running' THEN now() ELSE heartbeat_at END,
-                finished_at = CASE WHEN $2::VARCHAR IN ('succeeded','failed') THEN now() END,
+                finished_at = CASE WHEN $2::VARCHAR IN ('succeeded','failed','canceled') THEN now() END,
                 error = $3,
                 result = COALESCE($4, result)
-            WHERE id = $1
+            WHERE id = $1 AND state != 'canceled'
             """,
             job_id,
             new_state,


### PR DESCRIPTION
## Summary
- support `canceled` status in backend API
- add `/workflows/{workflow_id}/cancel` endpoint
- ensure worker does not overwrite canceled state
- expose cancel action in frontend UI and API
- style canceled state and extend models
- add tests for cancelation
- document installing deps before running frontend tests

## Testing
- `ruff check .`
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6868cf0188c88332943590ac12241cc4