### PR TITLE
Fix problem with dependencies between steps

### DIFF
--- a/awsl/deepresearch.awsl
+++ b/awsl/deepresearch.awsl
@@ -11,7 +11,7 @@ workflow DeepResearch {
   }
 
   outputs {
-    String final_answer
+    String final_answer = FinalAnswer.final_answer
   }
 
   # 1. Analyse the user’s query
@@ -47,7 +47,7 @@ workflow DeepResearch {
   # 3. Iterative research loop (up to 10 rounds or until we have a “GOOD” draft)
   cycle ResearchLoop {
     inputs {
-      String query              = query
+      String query              = AnalyseQuery.extended_query
       List<String> clarifications = AskUser.clarifications
       String next_query         = ""          # seed for first iteration
       String answer_draft       = ""          # empty draft to start
@@ -116,14 +116,6 @@ workflow DeepResearch {
     }
     outputs {
       String final_answer
-    }
-  }
-
-  # 5. Single exit node (no-op)
-  node End {
-    call noop
-    inputs {
-      String final_answer = FinalAnswer.final_answer
     }
   }
 }

--- a/awsl/sample.awsl
+++ b/awsl/sample.awsl
@@ -52,6 +52,7 @@ workflow SampleRAGWorkflow {
     call final_answer_generation
     inputs {
       String query        = query
+      String extended_query = QueryExtender.extended_query
       List<Chunk> chunks = FilterChunks.filtered_chunks
     }
     outputs {

--- a/awsl/sample.awsl
+++ b/awsl/sample.awsl
@@ -1,0 +1,61 @@
+workflow SampleRAGWorkflow {
+
+  metadata {
+    description: "Sample RAG workflow"
+    owner: "sample_team"
+    version: "1.0"
+  }
+
+  inputs {
+    String query
+  }
+
+  outputs {
+    String final_answer = FinalAnswer.final_answer
+  }
+
+  node QueryExtender {
+    call query_extender
+    inputs {
+      String query = query
+    }
+    outputs {
+      String extended_query
+    }
+  }
+
+  node Retrieve {
+    call retrieve_from_web
+    inputs {
+      String extended_query = QueryExtender.extended_query
+    }
+    outputs {
+      List<Chunk> chunks
+    }
+  }
+
+  node FilterChunks {
+    call filter_chunks
+    const {
+      llm_model: "gpt-4o"
+    }
+    inputs {
+      String query       = query
+      List<Chunk> chunks = Retrieve.chunks
+    }
+    outputs {
+      List<Chunk> filtered_chunks
+    }
+  }
+
+  node FinalAnswer {
+    call final_answer_generation
+    inputs {
+      String query        = query
+      List<Chunk> chunks = FilterChunks.filtered_chunks
+    }
+    outputs {
+      String final_answer
+    }
+  }
+}

--- a/tests/test_awsl_runner.py
+++ b/tests/test_awsl_runner.py
@@ -17,6 +17,9 @@ def filter_chunks(state: dict, config: dict) -> dict:
 
 
 def final_answer_generation(state: dict, config: dict) -> dict:
+    assert state.get("extended_query") == "extended query"
+    assert state.get("chunks") == ["chunk for hello"]
+    assert state.get("filtered_chunks") == ["chunk for hello"]
     return {"final_answer": "final answer from chunks"}
 
 

--- a/tests/test_awsl_runner.py
+++ b/tests/test_awsl_runner.py
@@ -1,43 +1,29 @@
 from awsl.run_awsl_workflow import run_workflow
 
-AWSL_PATH = "awsl/deepresearch.awsl"
+AWSL_PATH = "awsl/sample.awsl"
 
 
-def analyse_no_questions(state):
-    return {"extended_query": state.get("query", ""), "questions": []}
-
-
-def ask_questions(state):
-    return {"clarifications": "Interrested mostly in diagnostics"}
-
-
-def query_extender(state):
+def query_extender(state, config):
     return {"extended_query": "extended query"}
 
 
-def retrieve_from_web(state):
+def retrieve_from_web(state, config):
     return {"chunks": ["chunk for hello"]}
 
 
-def process_info(state):
-    return {"answer_draft": "answer draft"}
+def filter_chunks(state, config):
+    assert config.get("metadata", {}).get("llm_model") == "gpt-4o"
+    return {"filtered_chunks": ["chunk for hello"]}
 
 
-def answer_validate_good(state):
-    return {"is_enough": "GOOD", "next_query": ""}
+def final_answer_generation(state, config):
+    return {"final_answer": "final answer from chunks"}
 
 
-def final_answer_generation(state):
-    return {"final_answer": "final answer"}
-
-
-FN_MAP = {
-    "analyse_user_query": analyse_no_questions,
-    "ask_questions": ask_questions,
+FN_MAP = {  
     "query_extender": query_extender,
     "retrieve_from_web": retrieve_from_web,
-    "process_info": process_info,
-    "answer_validate": answer_validate_good,
+    "filter_chunks": filter_chunks,
     "final_answer_generation": final_answer_generation,
 }
 

--- a/tests/test_awsl_runner.py
+++ b/tests/test_awsl_runner.py
@@ -3,20 +3,20 @@ from awsl.run_awsl_workflow import run_workflow
 AWSL_PATH = "awsl/sample.awsl"
 
 
-def query_extender(state, config):
+def query_extender(state: dict, config: dict) -> dict:
     return {"extended_query": "extended query"}
 
 
-def retrieve_from_web(state, config):
+def retrieve_from_web(state: dict, config: dict) -> dict:
     return {"chunks": ["chunk for hello"]}
 
 
-def filter_chunks(state, config):
+def filter_chunks(state: dict, config: dict) -> dict:
     assert config.get("metadata", {}).get("llm_model") == "gpt-4o"
     return {"filtered_chunks": ["chunk for hello"]}
 
 
-def final_answer_generation(state, config):
+def final_answer_generation(state: dict, config: dict) -> dict:
     return {"final_answer": "final answer from chunks"}
 
 


### PR DESCRIPTION
My assumption was that Langgraph gathers all inputs from the incoming nodes before triggering target node but it doesn't work like this, it's triggers target node each time any of incoming nodes finishes its work. It means that the target node with 3 incoming nodes will be triggered three time and only on the third time it will have all the required inputs to process. 
The one exception is parallel nodes, if a target node has 3 incoming nodes, 2 of which are running in parallel, then it will be triggered only twice, because langgraph will wait for 2 parallel nodes to finish before triggering the target node. 

Another problem this PR is solving is making possible to reduce outputs from parallel nodes, now the reducer is very simple, just takes what is in the state and only if the field in the state is empty overwrites it with what comes from a node. 

The next steps:
1. adds ability to choose reducer (for instance, reducer that accumulate outputs of parallel nodes into list)
2. come up with an idea how to make this logic of waiting for all inputs before running the node with `when` expression and with possibility that some nodes will be omitted depending on when logic. So final answer step may depend on filtering step and optional addCitiations step that may be triggered or not depending on some other steps output. In this case if addCitations step is omitted then final answer step will never be triggered as it's waiting for all inputs to appear. 
3. in graph state we need to have fully qualified names of variables, like `workflow.query`, `AnalyseQuery.questions`, etc, instead of just `query` and `questions` because those names are local to steps and can interfere with each other. 